### PR TITLE
Add world-models.io knowledge hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ If you find this work helpful for your research, please kindly consider citing o
     - [Digital Twins](#four-digital-twins)
     - [Other Topics](#five-other-topics)
 - [6. Other Resources](#6-other-resources)
+    - [Knowledge Hubs](#knowledge-hubs)
     - [Tutorials](#tutorials)
     - [Talks \& Seminars](#talks--seminars)
 - [7. Acknowledgements](#7-acknowledgements)
@@ -632,6 +633,9 @@ Together, these models provide the foundation for simulation, planning, and embo
 
 # 6. Other Resources
 
+### Knowledge Hubs
+
+- [**world-models.io**](https://world-models.io/) — A structured knowledge hub for AI world models, with model profiles, research syntheses, comparisons, benchmarks, and a practical taxonomy spanning video, 3D/4D, occupancy, LiDAR, robotics, and autonomous driving. [Leaderboard](https://world-models.io/en/leaderboard/)
 
 ### Tutorials
 


### PR DESCRIPTION
## Summary

Adds [world-models.io](https://world-models.io/) under **Other Resources** as a knowledge hub for AI world models.

The resource complements the repository's 3D/4D coverage with model profiles, research syntheses, comparisons, benchmark-oriented evaluation context, and a practical taxonomy spanning video, occupancy, LiDAR, robotics, and autonomous driving.

## Changes

- Adds `Knowledge Hubs` to the table of contents.
- Adds one world-models.io entry under `# 6. Other Resources`, including its leaderboard.

## Validation

- `git diff --check`
- Documentation-only change to `README.md`