### PR TITLE
Add OpenWorldLib under a new Codebases & Toolkits subsection

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ If you find this work helpful for your research, please kindly consider citing o
     - [Digital Twins](#four-digital-twins)
     - [Other Topics](#five-other-topics)
 - [6. Other Resources](#6-other-resources)
+    - [Codebases \& Toolkits](#codebases--toolkits)
     - [Tutorials](#tutorials)
     - [Talks \& Seminars](#talks--seminars)
 - [7. Acknowledgements](#7-acknowledgements)
@@ -654,6 +655,9 @@ Together, these models provide the foundation for simulation, planning, and embo
 
 # 6. Other Resources
 
+### Codebases & Toolkits
+
+- [**OpenWorldLib**](https://github.com/OpenDCAI/OpenWorldLib) — A unified codebase for world models, providing a standardized pipeline interface over existing open-source models (Matrix-Game-2, Hunyuan-GameCraft, FlashWorld, Cosmos-Predict-2.5, and others) across video generation, 3D scene generation, and reasoning. Apache-2.0. [![GitHub](https://img.shields.io/github/stars/OpenDCAI/OpenWorldLib)](https://github.com/OpenDCAI/OpenWorldLib)
 
 ### Tutorials
 


### PR DESCRIPTION
Resolves #6.

Adds [OpenWorldLib](https://github.com/OpenDCAI/OpenWorldLib) (OpenDCAI), a unified codebase that wraps existing open-source world models behind a standardized pipeline interface, spanning video generation, 3D scene generation, and reasoning.

**Why include it**
- Apache-2.0, actively maintained (~850 stars, last push 2026-07-22).
- Integrates models already covered by this list (Matrix-Game-2, Hunyuan-GameCraft, FlashWorld, Cosmos-Predict-2.5).
- Precedent exists: OpenDWM is already listed in the LiDARGen tables as an open codebase.
- The section `6. Other Resources` previously contained only empty `Tutorials` and `Talks & Seminars` subsections; this gives it a first entry.

**Changes** — `README.md` only: one TOC line, one new `Codebases & Toolkits` subsection, one entry. Repo link verified (HTTP 200).