### PR TITLE
Add world-models.io under Knowledge Hubs (rebased #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ If you find this work helpful for your research, please kindly consider citing o
     - [Other Topics](#five-other-topics)
 - [6. Other Resources](#6-other-resources)
     - [Codebases \& Toolkits](#codebases--toolkits)
+    - [Knowledge Hubs](#knowledge-hubs)
     - [Tutorials](#tutorials)
     - [Talks \& Seminars](#talks--seminars)
 - [7. Acknowledgements](#7-acknowledgements)
@@ -658,6 +659,10 @@ Together, these models provide the foundation for simulation, planning, and embo
 ### Codebases & Toolkits
 
 - [**OpenWorldLib**](https://github.com/OpenDCAI/OpenWorldLib) — A unified codebase for world models, providing a standardized pipeline interface over existing open-source models (Matrix-Game-2, Hunyuan-GameCraft, FlashWorld, Cosmos-Predict-2.5, and others) across video generation, 3D scene generation, and reasoning. Apache-2.0. [![GitHub](https://img.shields.io/github/stars/OpenDCAI/OpenWorldLib)](https://github.com/OpenDCAI/OpenWorldLib)
+
+### Knowledge Hubs
+
+- [**world-models.io**](https://world-models.io/) — A structured knowledge hub for AI world models, with model profiles, research syntheses, comparisons, benchmarks, and a practical taxonomy spanning video, 3D/4D, occupancy, LiDAR, robotics, and autonomous driving. [Leaderboard](https://world-models.io/en/leaderboard/)
 
 ### Tutorials
 


### PR DESCRIPTION
Applies #13 on top of current main. The original branch became conflicted after #14 added a `Codebases & Toolkits` subsection to the same (previously empty) `6. Other Resources` section; the two subsections now sit side by side.

Identical in content to #13: one TOC line and one `Knowledge Hubs` entry.

Credit to @powehi-ai.